### PR TITLE
wrong path for the utm scss file

### DIFF
--- a/addons/utm/views/assets.xml
+++ b/addons/utm/views/assets.xml
@@ -2,7 +2,7 @@
 <odoo>
     <template id="assets_backend" name="utm assets" inherit_id="web.assets_backend">
         <xpath expr="link[last()]" position="after">
-            <link rel="stylesheet" type="text/scss" href="utm/static/src/scss/utm_views.scss"/>
+            <link rel="stylesheet" type="text/scss" href="/utm/static/src/scss/utm_views.scss"/>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
This path should be an absolute one.

Description of the issue/feature this PR addresses:
Fixing wrong file path of utm scss file.

Current behavior before PR:
System fails to load "utm/static/src/scss/web.assets_backend/utm_views.scss.css" 
(for all browsers)

Desired behavior after PR is merged:
No miss utm css files.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
